### PR TITLE
Adds Xcode 7.2 UUID to DVTPlugInCompatibilityUUIDs

### DIFF
--- a/YouCanDoIt/Info.plist
+++ b/YouCanDoIt/Info.plist
@@ -24,6 +24,7 @@
 	<string>1</string>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
+		<string>F41BD31E-2683-44B8-AE7F-5F09E919790E</string>
 		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>


### PR DESCRIPTION
I needed more Shia in my life but I was running Xcode 7.2, so I had to fix this.
